### PR TITLE
Make fixture panel scroll to selected component on page load

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "pretest": "jscs --esprima=esprima-fb ./",
     "test": "karma start --single-run",
     "coveralls": "cat tests/coverage/*/lcov.info | node_modules/coveralls/bin/coveralls.js",
-    "build": "webpack -p --watch",
+    "build": "webpack -p",
+    "watch": "npm run build -- --watch",
     "prepublish": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pretest": "jscs --esprima=esprima-fb ./",
     "test": "karma start --single-run",
     "coveralls": "cat tests/coverage/*/lcov.info | node_modules/coveralls/bin/coveralls.js",
-    "build": "webpack -p",
+    "build": "webpack -p --watch",
     "prepublish": "npm run build"
   }
 }

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -270,6 +270,10 @@ module.exports = React.createClass({
     window.addEventListener('resize', this.onWindowResize);
 
     this._updateContentFrameOrientation();
+
+    if(this.props.component) {
+      this.refs["componentName-" + this.props.component].getDOMNode().scrollIntoView(); 
+    }
   },
 
   componentWillReceiveProps: function(nextProps) {

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -271,8 +271,9 @@ module.exports = React.createClass({
 
     this._updateContentFrameOrientation();
 
-    if(this.props.component) {
-      this.refs["componentName-" + this.props.component].getDOMNode().scrollIntoView(); 
+    if (this.props.component) {
+      this.refs['componentName-' + this.props.component]
+        .getDOMNode().scrollIntoView({behavior:'smooth'});
     }
   },
 


### PR DESCRIPTION
## Need

``` gherkin
As a developer
I want the fixture panel to scroll to the currently selected component
So that I can easily locate the fixture/component I am using.
```
## Deliverables
- [x] On page load, the component panel is scrolled exactly to the selected fixture.
## Solution

Scroll to selected fixture's component after the main component finishes rendering.
