### PR TITLE
Make editor and preview panels resizable using react-split-pane

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,7 @@ module.exports = function(config) {
     webpack: {
       resolve: {
         alias: {
+          srclib: path.join(__dirname, 'src/lib'),
           components: path.join(__dirname, 'src/components'),
           fixtures: path.join(__dirname, 'fixtures'),
           tests: path.join(__dirname, 'tests')

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "style-loader": "^0.12.3",
+    "ubervu-react-split-pane": "^0.1.13",
     "webpack": "^1.8.2"
   },
   "peerDependencies": {

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -6,7 +6,8 @@ var _ = require('lodash'),
     ComponentTree = require('react-component-tree'),
     stringifyParams = require('react-querystring-router').uri.stringifyParams,
     parseLocation = require('react-querystring-router').uri.parseLocation,
-    isSerializable = require('../lib/is-serializable.js').isSerializable;
+    isSerializable = require('../lib/is-serializable.js').isSerializable,
+    SplitPane = require('ubervu-react-split-pane');
 
 module.exports = React.createClass({
   /**
@@ -180,13 +181,53 @@ module.exports = React.createClass({
     </ul>;
   },
 
-  _renderContentFrame: function() {
-    return <div ref="contentFrame" className={this._getContentFrameClasses()}>
+  _renderPreview: function() {
+    return (
       <div ref="previewContainer" className={this._getPreviewClasses()}>
         {this.loadChild('preview')}
       </div>
-      {this.props.editor ? this._renderFixtureEditor() : null}
-    </div>
+    );
+  },
+
+  _renderContentFrame: function() {
+    var split = this.state.orientation == 'landscape' ?
+      'vertical' : 'horizontal';
+    var classes = {
+      [style[split]] : true,
+      [style['split-pane']] : true
+    };
+    var resizerClasses = {
+      [style[split]] : true,
+      [style['resizer']] : true
+    }
+
+    classes = classNames(classes);
+    resizerClasses = classNames(resizerClasses);
+
+    // No need for a SplitPane if editor is not open
+    if (!this.props.editor) {
+      return (
+        <div ref="contentFrame" className={this._getContentFrameClasses()}>
+          {this._renderPreview()}
+        </div>
+      );
+    }
+
+    return (
+      <div ref="contentFrame" className={this._getContentFrameClasses()}>
+        <SplitPane  split={split}
+                    ref='editorPreviewSplitPane'
+                    defaultSize={localStorage.getItem('splitPos')}
+                    onChange={size => localStorage.setItem('splitPos', size)}
+                    minSize={20}
+                    className={classes}
+                    paneClassName=''
+                    resizerClassName={resizerClasses} >
+          {this._renderFixtureEditor()}
+          {this._renderPreview()}
+        </SplitPane>
+      </div>
+    );
   },
 
   _renderFixtureEditor: function() {

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -7,6 +7,7 @@ var _ = require('lodash'),
     stringifyParams = require('react-querystring-router').uri.stringifyParams,
     parseLocation = require('react-querystring-router').uri.parseLocation,
     isSerializable = require('../lib/is-serializable.js').isSerializable,
+    localStorageLib = require('../lib/local-storage.js'),
     SplitPane = require('ubervu-react-split-pane');
 
 module.exports = React.createClass({
@@ -116,6 +117,23 @@ module.exports = React.createClass({
       _.assign(params, this.state.fixtureUnserializableProps);
 
       return _.merge(params, _.omit(this.state.fixtureContents, 'state'));
+    },
+
+    splitPane: function() {
+      return {
+        component: SplitPane,
+        key: 'editorPreviewSplitPane',
+        split: this._getOrientationDirection(),
+        defaultSize: localStorageLib.get('splitPos'),
+        onChange: (function(size) {localStorageLib.set('splitPos', size)}),
+        minSize: 20,
+        className: this._getSplitPaneClasses('split-pane'),
+        resizerClassName: this._getSplitPaneClasses('resizer'),
+        children: [
+          this._renderFixtureEditor(),
+          this._renderPreview()
+        ]
+      };
     }
   },
 
@@ -183,11 +201,12 @@ module.exports = React.createClass({
     return <div ref="previewContainer" className={this._getPreviewClasses()}>
       {this.loadChild('preview')}
     </div>
+                key="previewContainer"
   },
 
   _renderContentFrame: function() {
     return <div ref="contentFrame" className={this._getContentFrameClasses()}>
-      {this.props.editor ? this._renderSplitPane() : this._renderPreview()}
+      {this.props.editor ? this.loadChild('splitPane') : this._renderPreview()}
     </div>
   },
 
@@ -221,7 +240,8 @@ module.exports = React.createClass({
       !this.state.isFixtureUserInputValid;
     editorClasses = classNames(editorClasses);
 
-    return <div className={style['fixture-editor-outer']}>
+    return <div key="fixture-editor-outer" 
+                className={style['fixture-editor-outer']}>
       <textarea ref="editor"
                 className={editorClasses}
                 value={this.state.fixtureUserInput}

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -211,21 +211,6 @@ module.exports = React.createClass({
     </div>
   },
 
-  _renderSplitPane: function() {
-    return <SplitPane
-      split={this._getOrientationDirection()}
-      ref='editorPreviewSplitPane'
-      defaultSize={localStorage.getItem('splitPos')}
-      onChange={size => localStorage.setItem('splitPos', size)}
-      minSize={20}
-      className={this._getSplitPaneClasses('split-pane')}
-      resizerClassName={this._getSplitPaneClasses('resizer')}
-    >
-      {this._renderFixtureEditor()}
-      {this._renderPreview()}
-    </SplitPane>
-  },
-
   _getOrientationDirection: function() {
     return this.state.orientation == 'landscape' ? 'vertical' : 'horizontal';
   },

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -198,10 +198,11 @@ module.exports = React.createClass({
   },
 
   _renderPreview: function() {
-    return <div ref="previewContainer" className={this._getPreviewClasses()}>
+    return <div ref="previewContainer"
+                key="previewContainer"
+                className={this._getPreviewClasses()}>
       {this.loadChild('preview')}
     </div>
-                key="previewContainer"
   },
 
   _renderContentFrame: function() {

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -125,7 +125,7 @@ module.exports = React.createClass({
         key: 'editorPreviewSplitPane',
         split: this._getOrientationDirection(),
         defaultSize: localStorageLib.get('splitPos'),
-        onChange: (function(size) {localStorageLib.set('splitPos', size)}),
+        onChange: (size => {localStorageLib.set('splitPos', size)}),
         minSize: 20,
         className: this._getSplitPaneClasses('split-pane'),
         resizerClassName: this._getSplitPaneClasses('resizer'),
@@ -240,7 +240,7 @@ module.exports = React.createClass({
       !this.state.isFixtureUserInputValid;
     editorClasses = classNames(editorClasses);
 
-    return <div key="fixture-editor-outer" 
+    return <div key="fixture-editor-outer"
                 className={style['fixture-editor-outer']}>
       <textarea ref="editor"
                 className={editorClasses}

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -127,20 +127,18 @@ module.exports = React.createClass({
     classes[style['full-screen']] = this.props.fullScreen;
     classes = classNames(classes);
 
-    return (
-      <div className={classes}>
-        <div className={style['left-nav']}>
-          <div className={style.header}>
-            {this._renderHomeButton()}
-            {isFixtureSelected ? this._renderMenu() : null}
-          </div>
-          <div className={style['fixtures']}>
-            {this._renderFixtures()}
-          </div>
+    return <div className={classes}>
+      <div className={style['left-nav']}>
+        <div className={style.header}>
+          {this._renderHomeButton()}
+          {isFixtureSelected ? this._renderMenu() : null}
         </div>
-        {isFixtureSelected ? this._renderContentFrame() : null}
+        <div className={style['fixtures']}>
+          {this._renderFixtures()}
+        </div>
       </div>
-    );
+      {isFixtureSelected ? this._renderContentFrame() : null}
+    </div>
   },
 
   _renderFixtures: function() {
@@ -182,11 +180,9 @@ module.exports = React.createClass({
   },
 
   _renderPreview: function() {
-    return (
-      <div ref="previewContainer" className={this._getPreviewClasses()}>
-        {this.loadChild('preview')}
-      </div>
-    );
+    return <div ref="previewContainer" className={this._getPreviewClasses()}>
+      {this.loadChild('preview')}
+    </div>
   },
 
   _renderContentFrame: function() {

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -190,35 +190,32 @@ module.exports = React.createClass({
   },
 
   _renderContentFrame: function() {
-    var split = this.state.orientation == 'landscape' ? 'vertical'
-                                                      : 'horizontal';
-    var classes = classNames(style[split], style['split-pane']);
-    var resizerClasses = classNames(style[split], style['resizer']);
+    return <div ref="contentFrame" className={this._getContentFrameClasses()}>
+      {this.props.editor ? this._renderSplitPane() : this._renderPreview()}
+    </div>
+  },
 
-    // No need for a SplitPane if editor is not open
-    if (!this.props.editor) {
-      return (
-        <div ref="contentFrame" className={this._getContentFrameClasses()}>
-          {this._renderPreview()}
-        </div>
-      );
-    }
+  _renderSplitPane: function() {
+    return <SplitPane
+      split={this._getOrientationDirection()}
+      ref='editorPreviewSplitPane'
+      defaultSize={localStorage.getItem('splitPos')}
+      onChange={size => localStorage.setItem('splitPos', size)}
+      minSize={20}
+      className={this._getSplitPaneClasses('split-pane')}
+      resizerClassName={this._getSplitPaneClasses('resizer')}
+    >
+      {this._renderFixtureEditor()}
+      {this._renderPreview()}
+    </SplitPane>
+  },
 
-    return (
-      <div ref="contentFrame" className={this._getContentFrameClasses()}>
-        <SplitPane split={split}
-                   ref='editorPreviewSplitPane'
-                   defaultSize={localStorage.getItem('splitPos')}
-                   onChange={size => localStorage.setItem('splitPos', size)}
-                   minSize={20}
-                   className={classes}
-                   paneClassName=''
-                   resizerClassName={resizerClasses} >
-          {this._renderFixtureEditor()}
-          {this._renderPreview()}
-        </SplitPane>
-      </div>
-    );
+  _getOrientationDirection: function() {
+    return this.state.orientation == 'landscape' ? 'vertical' : 'horizontal';
+  },
+
+  _getSplitPaneClasses: function(type) {
+    return classNames(style[this._getOrientationDirection()], style[type]);
   },
 
   _renderFixtureEditor: function() {

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -190,19 +190,10 @@ module.exports = React.createClass({
   },
 
   _renderContentFrame: function() {
-    var split = this.state.orientation == 'landscape' ?
-      'vertical' : 'horizontal';
-    var classes = {
-      [style[split]] : true,
-      [style['split-pane']] : true
-    };
-    var resizerClasses = {
-      [style[split]] : true,
-      [style['resizer']] : true
-    }
-
-    classes = classNames(classes);
-    resizerClasses = classNames(resizerClasses);
+    var split = this.state.orientation == 'landscape' ? 'vertical'
+                                                      : 'horizontal';
+    var classes = classNames(style[split], style['split-pane']);
+    var resizerClasses = classNames(style[split], style['resizer']);
 
     // No need for a SplitPane if editor is not open
     if (!this.props.editor) {
@@ -215,14 +206,14 @@ module.exports = React.createClass({
 
     return (
       <div ref="contentFrame" className={this._getContentFrameClasses()}>
-        <SplitPane  split={split}
-                    ref='editorPreviewSplitPane'
-                    defaultSize={localStorage.getItem('splitPos')}
-                    onChange={size => localStorage.setItem('splitPos', size)}
-                    minSize={20}
-                    className={classes}
-                    paneClassName=''
-                    resizerClassName={resizerClasses} >
+        <SplitPane split={split}
+                   ref='editorPreviewSplitPane'
+                   defaultSize={localStorage.getItem('splitPos')}
+                   onChange={size => localStorage.setItem('splitPos', size)}
+                   minSize={20}
+                   className={classes}
+                   paneClassName=''
+                   resizerClassName={resizerClasses} >
           {this._renderFixtureEditor()}
           {this._renderPreview()}
         </SplitPane>

--- a/src/components/component-playground.less
+++ b/src/components/component-playground.less
@@ -313,6 +313,7 @@
 
         &.disabled {
           cursor: not-allowed;
+          
           &:hover {
             border-color: transparent;
           }

--- a/src/components/component-playground.less
+++ b/src/components/component-playground.less
@@ -39,6 +39,11 @@
 @checkerboard-square-size: 25px;
 @checkerboard-color: #f1f1f1;
 
+@resizer-border-size: 5px;
+@resizer-width-height: 11px;
+@resizer-border-color: rgba(255, 255, 255, 0);
+@resizer-border-hover-color: rgba(0, 0, 0, 0.5);
+
 .component-playground {
   position: absolute;
   width: 100%;
@@ -208,41 +213,8 @@
     left: @left-nav-width;
     right: 0;
 
-    > .fixture-editor-outer {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      border: 1px solid @editor-border-color;
-      background: #f8f5ec;
-
-      .fixture-editor {
-        width: 100%;
-        height: 100%;
-        padding: @default-spacing;
-        box-sizing: border-box;
-        border: none;
-        background: transparent;
-        color: #637c84;
-        font-family: @editor-font-family;
-        font-size: @editor-font-size;
-        line-height: @editor-line-height;
-        resize: none;
-        outline: none;
-
-        &.invalid-syntax {
-          color: #cc7a6f;
-        }
-      }
-    }
-
     > .preview {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
+      height: 100%;
       overflow: auto;
       // Checkerboard effect on background
       background-image:
@@ -264,24 +236,100 @@
                            @checkerboard-square-size @checkerboard-square-size;
     }
 
-    &.with-editor {
-      &.orientation-landscape {
-        > .fixture-editor-outer {
-          right: 50%;
-        }
+    > .split-pane {
 
-        > .preview {
-          left: 50%;
+      .fixture-editor-outer {
+        height: 100%;
+        width: 100%;
+        border: 1px solid @editor-border-color;
+        background: #f8f5ec;
+
+        > .fixture-editor {
+          width: 100%;
+          height: 100%;
+          padding: @default-spacing;
+          box-sizing: border-box;
+          border: none;
+          background: transparent;
+          color: #637c84;
+          font-family: @editor-font-family;
+          font-size: @editor-font-size;
+          line-height: @editor-line-height;
+          resize: none;
+          outline: none;
+
+          &.invalid-syntax {
+            color: #cc7a6f;
+          }
         }
       }
 
-      &.orientation-portrait {
-        > .fixture-editor-outer {
-          bottom: 50%;
+      .preview {
+        height: 100%;
+        overflow: auto;
+        // Checkerboard effect on background
+        background-image:
+          linear-gradient(45deg,
+                          @checkerboard-color 25%,
+                          transparent 25%,
+                          transparent 75%,
+                          @checkerboard-color 75%,
+                          @checkerboard-color 100%),
+          linear-gradient(45deg,
+                          @checkerboard-color 25%,
+                          transparent 25%,
+                          transparent 75%,
+                          @checkerboard-color 75%,
+                          @checkerboard-color 100%);
+        background-size: 2 * @checkerboard-square-size
+                         2 * @checkerboard-square-size;
+        background-position: 0 0,
+                             @checkerboard-square-size @checkerboard-square-size;
+      }
+
+      .resizer {
+        background: #000;
+        opacity: .2;
+        z-index: 1;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box;
+        -moz-background-clip: padding;
+        -webkit-background-clip: padding;
+        background-clip: padding-box;
+
+        &.horizontal {
+          height: @resizer-width-height;
+          margin: -@resizer-border-size 0;
+          border-top: @resizer-border-size solid @resizer-border-color;
+          border-bottom: @resizer-border-size solid @resizer-border-color;
+          cursor: row-resize;
+          width: 100%;
+
+          &:hover {
+            border-top: @resizer-border-size solid @resizer-border-hover-color;
+            border-bottom: @resizer-border-size solid @resizer-border-hover-color;
+          }
         }
 
-        > .preview {
-          top: 50%;
+        &.vertical {
+          width: @resizer-width-height;
+          margin: 0 -@resizer-border-size;
+          border-left: @resizer-border-size solid @resizer-border-color;
+          border-right: @resizer-border-size solid @resizer-border-color;
+          cursor: col-resize;
+
+          &:hover {
+            border-left: @resizer-border-size solid @resizer-border-hover-color;
+            border-right: @resizer-border-size solid @resizer-border-hover-color;
+          }
+        }
+
+        &.disabled {
+          cursor: not-allowed;
+          &:hover {
+            border-color: transparent;
+          }
         }
       }
     }

--- a/src/components/component-playground.less
+++ b/src/components/component-playground.less
@@ -39,10 +39,10 @@
 @checkerboard-square-size: 25px;
 @checkerboard-color: #f1f1f1;
 
+@resizer-size: 1px;
+@resizer-color: fade(#aaa, 80%);
 @resizer-border-size: 5px;
-@resizer-width-height: 11px;
-@resizer-border-color: rgba(255, 255, 255, 0);
-@resizer-border-hover-color: rgba(0, 0, 0, 0.5);
+@resizer-border-hover-color: fade(#000, 15%);
 
 .component-playground {
   position: absolute;
@@ -288,41 +288,27 @@
       }
 
       .resizer {
-        background: #000;
-        opacity: .2;
+        background: @resizer-color;
         z-index: 1;
-        -moz-box-sizing: border-box;
-        -webkit-box-sizing: border-box;
-        box-sizing: border-box;
-        -moz-background-clip: padding;
-        -webkit-background-clip: padding;
         background-clip: padding-box;
+        border: solid transparent;
 
         &.horizontal {
-          height: @resizer-width-height;
+          height: @resizer-size;
+          border-width: @resizer-border-size 0;
           margin: -@resizer-border-size 0;
-          border-top: @resizer-border-size solid @resizer-border-color;
-          border-bottom: @resizer-border-size solid @resizer-border-color;
           cursor: row-resize;
-          width: 100%;
-
-          &:hover {
-            border-top: @resizer-border-size solid @resizer-border-hover-color;
-            border-bottom: @resizer-border-size solid @resizer-border-hover-color;
-          }
         }
 
         &.vertical {
-          width: @resizer-width-height;
+          width: @resizer-size;
+          border-width: 0 @resizer-border-size;
           margin: 0 -@resizer-border-size;
-          border-left: @resizer-border-size solid @resizer-border-color;
-          border-right: @resizer-border-size solid @resizer-border-color;
           cursor: col-resize;
+        }
 
-          &:hover {
-            border-left: @resizer-border-size solid @resizer-border-hover-color;
-            border-right: @resizer-border-size solid @resizer-border-hover-color;
-          }
+        &:hover {
+          border-color: @resizer-border-hover-color;
         }
 
         &.disabled {

--- a/src/lib/local-storage.js
+++ b/src/lib/local-storage.js
@@ -1,0 +1,25 @@
+module.exports = {
+  get: function(option) {
+    var stringifiedValue;
+
+    try {
+      stringifiedValue = localStorage.getItem(option);
+    } catch (e) {
+      stringifiedValue = null;
+    }
+
+    try {
+      return JSON.parse(stringifiedValue);
+    } catch (e) {
+      return null;
+    }
+  },
+
+  set: function(option, value) {
+    try {
+      return localStorage.setItem(option, JSON.stringify(value));
+    } catch (e) {
+      return null
+    }
+  }
+};

--- a/tests/components/component-playground/default/render/dom.js
+++ b/tests/components/component-playground/default/render/dom.js
@@ -69,6 +69,6 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   });
 
   it('should not render a splitpane', function() {
-    expect(component.refs.editorPreviewSplitPane).to.not.exist;
+    expect(component.refs.splitPane).to.not.exist;
   });
 });

--- a/tests/components/component-playground/default/render/dom.js
+++ b/tests/components/component-playground/default/render/dom.js
@@ -67,4 +67,8 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
     expect($(component.refs.homeButton.getDOMNode())
            .hasClass(style['selected-button'])).to.be.true;
   });
+
+  it('should not render a splitpane', function() {
+    expect(component.refs.editorPreviewSplitPane).to.not.exist;
+  });
 });

--- a/tests/components/component-playground/selected-fixture-and-editor/events/handlers.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/events/handlers.js
@@ -60,4 +60,33 @@ describe(`ComponentPlayground (${FIXTURE}) Events Handlers`, function() {
             .to.equal(JSON.stringify(fixture.state.fixtureContents, null, 2));
     });
   });
+
+  describe('Splitpane orientation', function() {
+    function simulateWindowResize(width, height) {
+      sinon.stub(component.refs.contentFrame, 'getDOMNode').returns({
+        offsetWidth: width,
+        offsetHeight: height
+      });
+
+      component.onWindowResize();
+    }
+
+    afterEach(function() {
+      component.refs.contentFrame.getDOMNode.restore();
+    });
+
+    it('should be set to horizontal on portrait orientation', function() {
+      simulateWindowResize(200, 300);
+
+      expect(component.refs.editorPreviewSplitPane.props.split)
+            .to.equal('horizontal');
+    });
+
+    it('should be set to vertical on landscape orientation', function() {
+      simulateWindowResize(300, 200);
+
+      expect(component.refs.editorPreviewSplitPane.props.split)
+            .to.equal('vertical');
+    });
+  });
 });

--- a/tests/components/component-playground/selected-fixture-and-editor/events/handlers.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/events/handlers.js
@@ -61,12 +61,12 @@ describe(`ComponentPlayground (${FIXTURE}) Events Handlers`, function() {
             .to.equal(JSON.stringify(fixture.state.fixtureContents, null, 2));
     });
 
-    it('should set', function() {
+    it('should set splitpane onChange to localstorage lib set', function() {
       expect(component.refs.splitPane.props.onChange())
         .to.equal(localStorageLib.set('splitPos'));
     });
 
-    it('should get', function() {
+    it('should set splitpane defaultSize to localstorage lib get', function() {
       expect(component.refs.splitPane.props.defaultSize)
         .to.equal(localStorageLib.get('splitPos'));
     });

--- a/tests/components/component-playground/selected-fixture-and-editor/events/handlers.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/events/handlers.js
@@ -2,6 +2,7 @@ var FIXTURE = 'selected-fixture-and-editor';
 
 describe(`ComponentPlayground (${FIXTURE}) Events Handlers`, function() {
   var ComponentTree = require('react-component-tree'),
+      localStorageLib = require('srclib/local-storage.js'),
       render = require('tests/lib/render-component.js'),
       fixture = require(`fixtures/component-playground/${FIXTURE}.js`);
 
@@ -59,34 +60,15 @@ describe(`ComponentPlayground (${FIXTURE}) Events Handlers`, function() {
       expect(stateSet.fixtureUserInput)
             .to.equal(JSON.stringify(fixture.state.fixtureContents, null, 2));
     });
-  });
 
-  describe('Splitpane orientation', function() {
-    function simulateWindowResize(width, height) {
-      sinon.stub(component.refs.contentFrame, 'getDOMNode').returns({
-        offsetWidth: width,
-        offsetHeight: height
-      });
-
-      component.onWindowResize();
-    }
-
-    afterEach(function() {
-      component.refs.contentFrame.getDOMNode.restore();
+    it('should set', function() {
+      expect(component.refs.splitPane.props.onChange())
+        .to.equal(localStorageLib.set('splitPos'));
     });
 
-    it('should be set to horizontal on portrait orientation', function() {
-      simulateWindowResize(200, 300);
-
-      expect(component.refs.editorPreviewSplitPane.props.split)
-            .to.equal('horizontal');
-    });
-
-    it('should be set to vertical on landscape orientation', function() {
-      simulateWindowResize(300, 200);
-
-      expect(component.refs.editorPreviewSplitPane.props.split)
-            .to.equal('vertical');
+    it('should get', function() {
+      expect(component.refs.splitPane.props.defaultSize)
+        .to.equal(localStorageLib.get('splitPos'));
     });
   });
 });

--- a/tests/components/component-playground/selected-fixture-and-editor/render/children.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/render/children.js
@@ -1,0 +1,23 @@
+var FIXTURE = 'selected-fixture-and-editor';
+
+describe(`ComponentPlayground (${FIXTURE}) Render Children`, function() {
+  var loadChild = require('react-component-tree').loadChild,
+      render = require('tests/lib/render-component.js'),
+      stubLoadChild = require('tests/setup/stub-load-child.js'),
+      fixture = require(`fixtures/component-playground/${FIXTURE}.js`);
+
+  var component,
+      $component,
+      container,
+      fixture;
+
+  stubLoadChild();
+
+  beforeEach(function() {
+    ({container, component, $component} = render(fixture));
+  });
+
+  it('should load preview and splitpane', function() {
+    expect(loadChild.loadChild).to.have.been.called.twice;
+  });
+});

--- a/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
@@ -46,7 +46,22 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
            .hasClass(style['invalid-syntax'])).to.be.true;
   });
 
-  it('should not render a splitpane', function() {
-    expect(component.refs.editorPreviewSplitPane).to.exist;
-  })
+  it('should render a splitpane ', function() {
+    expect(component.refs.splitPane).to.exist;
+  });
+
+  it('should add splitpane class on splitPane', function() {
+    expect($(component.refs.splitPane.getDOMNode())
+           .hasClass(style['split-pane'])).to.be.true;
+  });
+
+  it('should have proper split orientation on SplitPane', function() {
+    var splitByOrientation = {
+      portrait: 'horizontal',
+      landscape: 'vertical'
+    }
+
+    expect(component.refs.splitPane.props.split)
+      .to.equal(splitByOrientation[component.state.orientation]);
+  });
 });

--- a/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
@@ -45,4 +45,8 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
     expect($(component.refs.editor.getDOMNode())
            .hasClass(style['invalid-syntax'])).to.be.true;
   });
+
+  it('should not render a splitpane', function() {
+    expect(component.refs.editorPreviewSplitPane).to.exist;
+  })
 });


### PR DESCRIPTION
## Need

``` gherkin
As a developer
I want to be able to resize the editor panel
So that I can use the screen space efficiently.
```
## Deliverables
- [x] The separator between the editor and preview panes can be dragged to resize them (when the editor pane enlarges, the preview pane shrinks and vice versa)
## Solution
#### Prerequisites
- Use the React SplitPane component located [here](https://github.com/ubervu/react-split-pane)
#### TODO
- [x] Add the editor and preview pane components to a SplitPane 
- [x] Check if any rendering tests fail, and adapt them to the new component
