### PR TITLE
Restore 100% line coverage

### DIFF
--- a/fixtures/component-playground/default.js
+++ b/fixtures/component-playground/default.js
@@ -50,7 +50,6 @@ module.exports = {
     }
   },
   router: {
-    routeLink: function() {},
     goTo: function() {}
   }
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,6 +9,7 @@ module.exports = function(config) {
       dir: 'coverage/'
     },
     files: [
+      'local-storage.js',
       'bind-polyfill.js',
       'components/**/*.js',
       'actions/*.js',

--- a/tests/local-storage.js
+++ b/tests/local-storage.js
@@ -1,0 +1,46 @@
+/* global localStorage */
+
+describe('Local storage lib', function() {
+  var localStorageLib = require('src/lib/local-storage.js');
+
+  beforeEach(function() {
+    sinon.stub(localStorage, 'getItem');
+    sinon.stub(localStorage, 'setItem');
+  });
+
+  afterEach(function() {
+    localStorage.getItem.restore();
+    localStorage.setItem.restore();
+    localStorage.clear();
+  });
+
+  it('should call localStorage get on lib get', function() {
+    localStorageLib.get();
+
+    expect(localStorage.getItem).to.have.been.called;
+  });
+
+  it('should return null on local storage get error', function() {
+    localStorage.getItem.throws();
+
+    expect(localStorageLib.get()).to.be.null;
+  });
+
+  it('should return null on parsing error', function() {
+    localStorageLib.set('foo', {foo: 'bar'});
+
+    expect(localStorageLib.get('foo')).to.be.null;
+  });
+
+  it('should call localStorage set on lib set', function() {
+    localStorageLib.set();
+
+    expect(localStorage.setItem).to.have.been.called;
+  });
+
+  it('should return null on local storage set error', function() {
+    localStorage.setItem.throws();
+
+    expect(localStorageLib.set()).to.be.null;
+  });
+});


### PR DESCRIPTION
With the introduction of the [local storage lib](https://github.com/uberVU/react-component-playground/blob/0.3.x/src/lib/local-storage.js) in `local-storage.js`, line coverage has dropped below the initial 100%.

We need to restore it by refactoring the lib and/or adding more tests to cover all available cases.
