### PR TITLE
Apply generic store state on mount

### DIFF
--- a/src/actions/reset-store.js
+++ b/src/actions/reset-store.js
@@ -1,0 +1,12 @@
+var RESET_STORE = 'RESET_STORE';
+
+module.exports = {
+  type: RESET_STORE,
+
+  resetStore: function(reduxStore) {
+    return {
+      type: RESET_STORE,
+      reduxStore: reduxStore
+    };
+  }
+};

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -359,6 +359,7 @@ module.exports = React.createClass({
   componentWillReceiveProps: function(nextProps) {
     if (this.constructor.didFixtureChange(this.props, nextProps)) {
       var nextState = this.constructor.getFixtureState(nextProps);
+
       this.setState(nextState);
       store.dispatch(resetStore(this.props.reduxStore));
       store.dispatch(changeFixture(nextState.fixtureContents));

--- a/src/reducers/entire-store.js
+++ b/src/reducers/entire-store.js
@@ -1,4 +1,6 @@
-var CHANGE_FIXTURE = require('../actions/change-fixture.js').type;
+var CHANGE_FIXTURE = require('../actions/change-fixture.js').type,
+    RESET_STORE = require('../actions/reset-store.js').type,
+    _ = require('lodash');
 
 module.exports = function(state, action) {
   if (typeof state === 'undefined') {
@@ -8,9 +10,11 @@ module.exports = function(state, action) {
   switch (action.type) {
     case CHANGE_FIXTURE:
       if (action.fixture && action.fixture.reduxStore) {
-        return action.fixture.reduxStore;
+        return _.merge({}, state, action.fixture.reduxStore);
       }
-      return {};
+      return state;
+    case RESET_STORE:
+      return action.reduxStore;
     default:
       return state;
   }

--- a/tests/actions/reset-store.js
+++ b/tests/actions/reset-store.js
@@ -1,0 +1,13 @@
+describe('Reset store actions', function() {
+  var resetStore = require('src/actions/reset-store.js');
+
+  it('should create the correct action', function() {
+    var reduxStore = {id: 1, name: 'John'};
+    var expectedAction = {
+      type: resetStore.type,
+      reduxStore: reduxStore
+    };
+
+    expect(resetStore.resetStore(reduxStore)).to.deep.equal(expectedAction);
+  });
+});

--- a/tests/reducers/entire-store.js
+++ b/tests/reducers/entire-store.js
@@ -1,5 +1,6 @@
-var reducer = require('src/reducers/entire-store.js');
-var CHANGE_FIXTURE = require('src/actions/change-fixture.js').type;
+var reducer = require('src/reducers/entire-store.js'),
+    CHANGE_FIXTURE = require('src/actions/change-fixture.js').type,
+    RESET_STORE = require('src/actions/reset-store.js').type;
 
 describe('Change fixture reducer', function() {
   it('should return the initial state', function() {
@@ -13,19 +14,17 @@ describe('Change fixture reducer', function() {
     };
 
     var action = {
-      type: CHANGE_FIXTURE,
-      fixture: {
-        reduxStore: {
-          id: 1,
-          name: 'John'
-        }
+      type: RESET_STORE,
+      reduxStore: {
+        id: 1,
+        name: 'John'
       }
     };
 
     expect(reducer({}, action)).to.deep.equal(expectedState);
   });
 
-  it('should return empty state on undefined fixture', function() {
+  it('should return initial state on undefined fixture', function() {
     var initialState = {
       reduxStore: {
         id: 1,
@@ -37,7 +36,23 @@ describe('Change fixture reducer', function() {
       type: CHANGE_FIXTURE
     };
 
-    expect(reducer(initialState, action)).to.be.empty;
+    expect(reducer(initialState, action)).to.deep.equal(initialState);
+  });
+
+  it('should merge in new values correctly', function() {
+    var initialState = {id: 1, name: 'John'},
+        expectedState = {id: 2, name: 'John'};
+
+    var action = {
+      type: CHANGE_FIXTURE,
+      fixture: {
+        reduxStore: {
+          id: 2
+        }
+      }
+    };
+
+    expect(reducer(initialState, action)).to.deep.equal(expectedState);
   });
 
   it('should maintain state when receiving an unknown action', function() {


### PR DESCRIPTION
Instead of applying the full store state when rendering a fixture, do the following:
- Receive a default store through props.
- Apply default store on mount and on fixture change.
- When selecting a fixture containing the `reduxStore` key, merge that value into the generic store.
